### PR TITLE
Fixed unintended variable mixup

### DIFF
--- a/XlsxReaderWriter/BRAStyles.m
+++ b/XlsxReaderWriter/BRAStyles.m
@@ -353,8 +353,8 @@
     NSMutableArray *stylesFormattingRecordsArray = [dictionaryRepresentation arrayValueForKeyPath:@"cellStyleXfs.xf"].mutableCopy;
     NSInteger oldStylesFormattingRecordsCount = [stylesFormattingRecordsArray count];
     
-    for (NSInteger i = oldStylesFormattingRecordsCount; i < _cellFormats.count; i++) {
-        [stylesFormattingRecordsArray addObject:[_cellFormats[i] dictionaryRepresentation]];
+    for (NSInteger i = oldStylesFormattingRecordsCount; i < _cellStyleFormats.count; i++) {
+        [stylesFormattingRecordsArray addObject:[_cellStyleFormats[i] dictionaryRepresentation]];
     }
     
     if (stylesFormattingRecordsArray.count > oldStylesFormattingRecordsCount) {


### PR DESCRIPTION
Fixed a bug that caused an invalid styles.xml. The variable _cellFormats was used instead of the intended _cellStyleFormats