### PR TITLE
fixes mac compilation error related to out-of-scope variable

### DIFF
--- a/XlsxReaderWriter/BRACellFill.m
+++ b/XlsxReaderWriter/BRACellFill.m
@@ -128,11 +128,9 @@
     CGContextRef context = CGBitmapContextCreate(NULL, drawingSize.width, drawingSize.height, 8, 0, colorSpace, kCGImageAlphaPremultipliedLast);
     
     drawingOps(context);
-    
-    CGImageRef imageRef = CGBitmapContextCreateImage(context);
+        
     BRANativeImage *patternImage = BRANativeGraphicsGetImageFromCurrentImageContext(context);
     
-    CGImageRelease(imageRef);
     CGContextRelease(context);
     CGColorSpaceRelease(colorSpace);
     

--- a/XlsxReaderWriter/BRAPlatformSpecificDefines.h
+++ b/XlsxReaderWriter/BRAPlatformSpecificDefines.h
@@ -65,8 +65,11 @@ NS_INLINE NSData* BRANativeImageJPEGRepresentation(NSImage *image, CGFloat quali
 
 
 NS_INLINE BRANativeImage* BRANativeGraphicsGetImageFromCurrentImageContext(CGContextRef context) {
-    return [[BRANativeImage alloc] initWithCGImage:imageRef
+    CGImageRef imageRef = CGBitmapContextCreateImage(context);
+    BRANativeImage *img = [[BRANativeImage alloc] initWithCGImage:imageRef
                                               size:CGSizeMake(CGBitmapContextGetWidth(context), CGBitmapContextGetHeight(context))];
+    CGImageRelease(imageRef);
+    return img;
 }
 
 #endif /* BRAPlatformSpecificDefines_h */


### PR DESCRIPTION
This change should not affect iOS at all, since `UIGraphicsGetImageFromCurrentImageContext` does not make use of `imageRef`