### PR TITLE
XMLDictionary import fixed

### DIFF
--- a/XlsxReaderWriter/BRAOpenXmlSubElement.h
+++ b/XlsxReaderWriter/BRAOpenXmlSubElement.h
@@ -7,9 +7,9 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <XMLDictionary/XMLDictionary.h>
 #import "NativeColor+HTML.h"
 #import "NativeFont+BoldItalic.h"
-#import "XMLDictionary.h"
 #import "NSDictionary+DeepCopy.h"
 #import "NSDictionary+OpenXmlString.h"
 #import "NSDictionary+OpenXMLDictionaryParser.h"

--- a/XlsxReaderWriter/BRARelationship.h
+++ b/XlsxReaderWriter/BRARelationship.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "XMLDictionary.h"
+#import <XMLDictionary/XMLDictionary.h>
 #import "NativeColor+OpenXML.h"
 #import "BRAElementWithRelationships.h"
 

--- a/XlsxReaderWriter/NSDictionary+OpenXMLDictionaryParser.h
+++ b/XlsxReaderWriter/NSDictionary+OpenXMLDictionaryParser.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 René Bigot. All rights reserved.
 //
 
-#import "XMLDictionary.h"
+#import <XMLDictionary/XMLDictionary.h>
 
 @interface NSDictionary (OpenXmlDictionaryParser)
 

--- a/XlsxReaderWriter/NSDictionary+OpenXmlString.h
+++ b/XlsxReaderWriter/NSDictionary+OpenXmlString.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "XMLDictionary.h"
+#import <XMLDictionary/XMLDictionary.h>
 
 @interface NSDictionary (OpenXmlString)
 

--- a/XlsxReaderWriter/XlsxReaderWriter-swift-bridge.h
+++ b/XlsxReaderWriter/XlsxReaderWriter-swift-bridge.h
@@ -6,11 +6,10 @@
 //  Copyright (c) 2015 René Bigot. All rights reserved.
 //
 
-
+#import <XMLDictionary/XMLDictionary.h>
 #import "NativeFont+BoldItalic.h"
 #import "NativeColor+OpenXML.h"
 #import "NativeColor+HTML.h"
-#import "XMLDictionary.h"
 #import "NSDictionary+OpenXmlString.h"
 #import "NSDictionary+OpenXMLDictionaryParser.h"
 #import "NSDictionary+DeepCopy.h"


### PR DESCRIPTION
XMLDictionary import needs to be converted to angle bracket form to work with CocoaPods, as a subproject, etc on the first go.