### PR TITLE
Issue-27 - fix ordering of alignment and protection elements under xf

### DIFF
--- a/XlsxReaderWriter/NSDictionary+OpenXmlString.m
+++ b/XlsxReaderWriter/NSDictionary+OpenXmlString.m
@@ -89,7 +89,7 @@
                                  @"numFmtId", @"formatCode"
                                  ],
                          @"xf": @[
-                                 @"numFmtId", @"fontId", @"fillId", @"borderId", @"xfId", @"applyNumberFormat", @"applyFont", @"applyFill", @"applyBorder", @"applyAlignment", @"applyProtection", @"Alignment", @"Protection", @"ExtensionList"
+                                 @"numFmtId", @"fontId", @"fillId", @"borderId", @"xfId", @"applyNumberFormat", @"applyFont", @"applyFill", @"applyBorder", @"applyAlignment", @"applyProtection", @"alignment", @"protection", @"ExtensionList"
                                  ],
                          @"col": @[
                                  @"min", @"max", @"width", @"bestFit", @"style", @"customWidth"


### PR DESCRIPTION
'alignment' and 'protection' elements were capitalised, leading to incorrect ordering of these elements in the stylesheet.