### PR TITLE
Dev/cocoapods frameworks support

### DIFF
--- a/XlsxReaderWriter/BRACalcChain.m
+++ b/XlsxReaderWriter/BRACalcChain.m
@@ -10,6 +10,7 @@
 #import "BRARow.h"
 #import "BRACell.h"
 #import "BRAColumn.h"
+@import XMLDictionary;
 
 @implementation BRACalcChain
 

--- a/XlsxReaderWriter/BRACell.m
+++ b/XlsxReaderWriter/BRACell.m
@@ -13,6 +13,7 @@
 #import "BRAWorksheet.h"
 #import "BRADrawing.h"
 #import "BRACellFormat.h"
+@import XMLDictionary;
 
 @implementation BRACell
 

--- a/XlsxReaderWriter/BRACellFormat.m
+++ b/XlsxReaderWriter/BRACellFormat.m
@@ -9,6 +9,7 @@
 #import "BRACellFormat.h"
 #import "BRAStyles.h"
 #import "BRACellFill.h"
+@import XMLDictionary;
 
 @implementation BRACellFormat
 

--- a/XlsxReaderWriter/BRAColumn.m
+++ b/XlsxReaderWriter/BRAColumn.m
@@ -7,6 +7,7 @@
 //
 
 #import "BRAColumn.h"
+@import XMLDictionary;
 
 #define TRUNCATE(X) floor(X)
 

--- a/XlsxReaderWriter/BRAComments.m
+++ b/XlsxReaderWriter/BRAComments.m
@@ -10,6 +10,7 @@
 #import "BRARow.h"
 #import "BRACell.h"
 #import "BRAColumn.h"
+@import XMLDictionary;
 
 @implementation BRAComments
 

--- a/XlsxReaderWriter/BRAContentTypesDefaultExtension.m
+++ b/XlsxReaderWriter/BRAContentTypesDefaultExtension.m
@@ -8,6 +8,7 @@
 
 #import "BRAContentTypesDefaultExtension.h"
 #import "BRARelationship.h"
+@import XMLDictionary;
 
 @implementation BRAContentTypesDefaultExtension
 

--- a/XlsxReaderWriter/BRAContentTypesOverride.m
+++ b/XlsxReaderWriter/BRAContentTypesOverride.m
@@ -8,6 +8,7 @@
 
 #import "BRAContentTypesOverride.h"
 #import "BRARelationship.h"
+@import XMLDictionary;
 
 @implementation BRAContentTypesOverride
 

--- a/XlsxReaderWriter/BRADrawing.m
+++ b/XlsxReaderWriter/BRADrawing.m
@@ -10,6 +10,7 @@
 #import "BRARow.h"
 #import "BRACell.h"
 #import "BRAColumn.h"
+@import XMLDictionary;
 
 #define ONE_CELL_ANCHOR @"xdr:oneCellAnchor"
 #define TWO_CELL_ANCHOR @"xdr:twoCellAnchor"

--- a/XlsxReaderWriter/BRAOfficeDocument.m
+++ b/XlsxReaderWriter/BRAOfficeDocument.m
@@ -11,6 +11,7 @@
 #import "BRASharedStrings.h"
 #import "BRAWorksheet.h"
 #import "BRASheet.h"
+@import XMLDictionary;
 
 @implementation BRAOfficeDocument
 

--- a/XlsxReaderWriter/BRAOfficeDocumentPackage.m
+++ b/XlsxReaderWriter/BRAOfficeDocumentPackage.m
@@ -53,7 +53,7 @@
         //Unpack the OPC package
         NSString *subCacheDirectory = [@"fr.brae.spreadsheetdocument" stringByAppendingPathComponent:[filePath lastPathComponent]];
         self.cacheDirectory = [[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject] stringByAppendingPathComponent:subCacheDirectory];
-        
+        [[NSFileManager defaultManager] createDirectoryAtPath:self.cacheDirectory withIntermediateDirectories:YES attributes:nil error:NULL];
         [SSZipArchive unzipFileAtPath:filePath toDestination:self.cacheDirectory];
         
         

--- a/XlsxReaderWriter/BRAOfficeDocumentPackage.m
+++ b/XlsxReaderWriter/BRAOfficeDocumentPackage.m
@@ -7,7 +7,7 @@
 //
 
 #import "BRAOfficeDocumentPackage.h"
-#import "SSZipArchive.h"
+@import SSZipArchive;
 #import "BRAContentTypes.h"
 #import "BRARelationships.h"
 

--- a/XlsxReaderWriter/BRAOpenXmlSubElement.h
+++ b/XlsxReaderWriter/BRAOpenXmlSubElement.h
@@ -9,7 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "NativeColor+HTML.h"
 #import "NativeFont+BoldItalic.h"
-#import "XMLDictionary.h"
 #import "NSDictionary+DeepCopy.h"
 #import "NSDictionary+OpenXmlString.h"
 #import "NSDictionary+OpenXMLDictionaryParser.h"

--- a/XlsxReaderWriter/BRAOpenXmlSubElement.m
+++ b/XlsxReaderWriter/BRAOpenXmlSubElement.m
@@ -8,6 +8,7 @@
 
 #import "BRAOpenXmlSubElement.h"
 #import "BRAStyles.h"
+@import XMLDictionary;
 
 @implementation BRAOpenXmlSubElement
 

--- a/XlsxReaderWriter/BRARelationship.h
+++ b/XlsxReaderWriter/BRARelationship.h
@@ -7,7 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "XMLDictionary.h"
 #import "NativeColor+OpenXML.h"
 #import "BRAElementWithRelationships.h"
 

--- a/XlsxReaderWriter/BRARelationship.m
+++ b/XlsxReaderWriter/BRARelationship.m
@@ -8,6 +8,7 @@
 
 #import "BRARelationship.h"
 #import "BRARelationships.h"
+@import XMLDictionary;
 
 @implementation BRARelationship
 

--- a/XlsxReaderWriter/BRARelationships.m
+++ b/XlsxReaderWriter/BRARelationships.m
@@ -10,6 +10,7 @@
 #import "BRAContentTypesDefaultExtension.h"
 #import "BRAContentTypesOverride.h"
 #import "BRADrawing.h"
+@import XMLDictionary;
 
 @implementation BRARelationships
 

--- a/XlsxReaderWriter/BRARow.m
+++ b/XlsxReaderWriter/BRARow.m
@@ -11,6 +11,7 @@
 #import "BRAMergeCell.h"
 #import "BRAWorksheet.h"
 #import "BRAColumn.h"
+@import XMLDictionary;
 
 @implementation BRARow
 

--- a/XlsxReaderWriter/BRASharedString.m
+++ b/XlsxReaderWriter/BRASharedString.m
@@ -7,6 +7,7 @@
 //
 
 #import "BRASharedString.h"
+@import XMLDictionary;
 
 @implementation BRASharedString
 

--- a/XlsxReaderWriter/BRASharedStrings.m
+++ b/XlsxReaderWriter/BRASharedStrings.m
@@ -9,6 +9,7 @@
 #import "BRASharedStrings.h"
 #import "BRAStyles.h"
 #import "BRASharedString.h"
+@import XMLDictionary;
 
 @implementation BRASharedStrings
 

--- a/XlsxReaderWriter/BRAStyles.m
+++ b/XlsxReaderWriter/BRAStyles.m
@@ -9,6 +9,7 @@
 #import "BRAStyles.h"
 #import "BRACellFill.h"
 #import "BRACellFormat.h"
+@import XMLDictionary;
 
 @implementation BRAStyles
 

--- a/XlsxReaderWriter/BRATheme.m
+++ b/XlsxReaderWriter/BRATheme.m
@@ -8,6 +8,7 @@
 
 #import "BRATheme.h"
 #import "NativeColor+HTML.h"
+@import XMLDictionary;
 
 // It seems thats S01 & S00 have been switched compared to IEC 29500-1.
 // Don't know why !!!

--- a/XlsxReaderWriter/BRAWorksheet.m
+++ b/XlsxReaderWriter/BRAWorksheet.m
@@ -11,6 +11,7 @@
 #import "BRARow.h"
 #import "BRARelationships.h"
 #import "BRAPlatformSpecificDefines.h"
+@import XMLDictionary;
 
 @implementation BRAWorksheet
 

--- a/XlsxReaderWriter/NSDictionary+OpenXMLDictionaryParser.h
+++ b/XlsxReaderWriter/NSDictionary+OpenXMLDictionaryParser.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 René Bigot. All rights reserved.
 //
 
-#import "XMLDictionary.h"
+@class NSXMLParser;
 
 @interface NSDictionary (OpenXmlDictionaryParser)
 

--- a/XlsxReaderWriter/NSDictionary+OpenXMLDictionaryParser.m
+++ b/XlsxReaderWriter/NSDictionary+OpenXMLDictionaryParser.m
@@ -7,6 +7,7 @@
 //
 
 #import "NSDictionary+OpenXmlDictionaryParser.h"
+@import XMLDictionary;
 
 @implementation NSDictionary (OpenXmlDictionaryParser)
 

--- a/XlsxReaderWriter/NSDictionary+OpenXmlString.h
+++ b/XlsxReaderWriter/NSDictionary+OpenXmlString.h
@@ -7,7 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "XMLDictionary.h"
 
 @interface NSDictionary (OpenXmlString)
 

--- a/XlsxReaderWriter/NSDictionary+OpenXmlString.m
+++ b/XlsxReaderWriter/NSDictionary+OpenXmlString.m
@@ -7,6 +7,7 @@
 //
 
 #import "NSDictionary+OpenXmlString.h"
+@import XMLDictionary;
 
 @implementation NSDictionary (OpenXmlString)
 

--- a/XlsxReaderWriter/XlsxReaderWriter-swift-bridge.h
+++ b/XlsxReaderWriter/XlsxReaderWriter-swift-bridge.h
@@ -6,11 +6,11 @@
 //  Copyright (c) 2015 René Bigot. All rights reserved.
 //
 
+@import XMLDictionary;
 
 #import "NativeFont+BoldItalic.h"
 #import "NativeColor+OpenXML.h"
 #import "NativeColor+HTML.h"
-#import "XMLDictionary.h"
 #import "NSDictionary+OpenXmlString.h"
 #import "NSDictionary+OpenXMLDictionaryParser.h"
 #import "NSDictionary+DeepCopy.h"


### PR DESCRIPTION
this should sort your cocoa pods issue an some Xcode 8 issues.

FYI. I found a bug with SSZipArchive where we need to create the folder before extracting the Zip.
see : BRAOfficeDocumentPackage.m

Warning this pull request means you will need to use   `use_frameworks!`  in your pod file

Pod file example if you want to test it before merging:

``` Ruby
target 'My great app do

    # pod 'XlsxReaderWriter'
    pod 'XlsxReaderWriter', :git => 'git@github.com:charlymr/XlsxReaderWriter.git', :commit => 'e4e941746aa14938ee02652082ec408efb7ab9c3'
    pod 'Fabric'
    pod 'Crashlytics'

    use_frameworks!
end
```
